### PR TITLE
Unify naming conventions

### DIFF
--- a/_posts/2020-11-15-past-exeuctive-committees.markdown
+++ b/_posts/2020-11-15-past-exeuctive-committees.markdown
@@ -9,8 +9,8 @@ Listed below are the executive committees of the mathematics society over the ye
 #### 2021-22
 
 | President                     | Li Chun Lok                   | 4F                            |
-| Vice President                | Sit Pok Shun                  | 4F                            |
-| Vice President                | Mak Tsz Long                  | 4F                            |
+| Vice President                | Sit Pok Shun Jaden            | 4F                            |
+| Vice President                | Mak Tsz Long Gavin            | 4F                            |
 | Internal Secretary            | Chiu Pak Hei                  | 3E                            |
 | Financial Secretary           | Tse Wilson                    | 4F                            |
 | Maths Designer                | Fok Pak Yin                   | 4E                            |


### PR DESCRIPTION
Urgency: Low
Sit Pok Shun Jaden & Mak Tsz Long Gavin are School-Registered names.
Displayed names lack the English first name, despite the excos being registered with these names. 
Several other names with English registered names are seen throughout the past exco list. (Justin Cheng, 2010-11 committees). This shows that the naming convention of these two entries is inconsistent with other records.
This is mostly just a test lol but yeah it's a problem